### PR TITLE
add braindb to See also

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The workflow is based on a real knowledge base with 94 articles and 99 sources m
 
 Unofficial community implementation of the workflow from [Karpathy's LLM Wiki idea](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). The value here is the reusable workflow, prompt structure, and battle-tested knowledge-compilation rules.
 
-See also: [lucasastorian/llmwiki](https://github.com/lucasastorian/llmwiki), [atomicmemory/llm-wiki-compiler](https://github.com/atomicmemory/llm-wiki-compiler).
+See also: [lucasastorian/llmwiki](https://github.com/lucasastorian/llmwiki), [atomicmemory/llm-wiki-compiler](https://github.com/atomicmemory/llm-wiki-compiler), [dimknaf/braindb](https://github.com/dimknaf/braindb).
 
 ## License
 


### PR DESCRIPTION
appends `dimknaf/braindb` to the `See also` comma-list at the bottom of the Inspired By section. one-character precision edit, matches the existing format exactly.

braindb is another implementation of Karpathy's wiki pattern — server-shaped (Postgres + pgvector + REST API + maintainer agent) where the existing See-also entries are CLI / MCP. fits the same audience.

— @dimknaf
